### PR TITLE
Props node size

### DIFF
--- a/__tests__/components/graph-view.test.js
+++ b/__tests__/components/graph-view.test.js
@@ -105,7 +105,7 @@ describe('GraphView component', () => {
 
   describe('render method', () => {
     it('renders', () => {
-      expect(output.props().className).toEqual('view-wrapper');
+      expect(output.props().className).toEqual('main-graph-wrapper');
 
       expect(output.find('.graph-controls-wrapper').length).toEqual(1);
 

--- a/src/components/graph-minimap.js
+++ b/src/components/graph-minimap.js
@@ -1,0 +1,69 @@
+// @flow
+/*
+  Copyright(c) 2018 Uber Technologies, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/*
+  Zoom slider and zoom to fit controls for GraphView
+*/
+import * as d3 from 'd3';
+import React from 'react';
+
+class GraphMinimap extends React.Component {
+  graphMinimapSvg
+
+  constructor(props) {
+    super(props);
+    this.graphMinimapSvg = React.createRef();
+  }
+
+  renderMinimap() {
+    let data = this.props.entities.cloneNode(true)
+    const viewBBox = this.props.entities.getBBox ? this.props.entities.getBBox() : null;
+    const graphMinimapWrapper = this.graphMinimapSvg.current
+    const height = this.props.viewWrapper.current.clientHeight
+    graphMinimapWrapper.setAttribute('viewBox', [viewBBox.x, viewBBox.y, viewBBox.width, viewBBox.height].join(' '))
+    graphMinimapWrapper.setAttribute('height', height)
+    data.childNodes.forEach(element => {
+      element.id = "minimap_" + element.id
+    });
+    graphMinimapWrapper.prepend(data)
+
+  }
+
+  componentDidMount() {
+    this.renderMinimap()
+  }
+
+  componentDidUpdate(prevProps) {
+    const graphMinimapWrapper = this.graphMinimapSvg.current
+    const graphMinimapWrapperEntities = graphMinimapWrapper.querySelector('.entities')
+    graphMinimapWrapperEntities.remove()
+    this.renderMinimap()
+  }
+
+  render() {
+    const width_minimap = 250
+
+    return (
+        <div id="minimap">
+            <svg ref={this.graphMinimapSvg} width={ width_minimap }>
+            </svg>
+        </div>
+    );
+  }
+}
+
+export default GraphMinimap;

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -35,6 +35,9 @@ export type IGraphViewProps = {
   nodeKey: string;
   nodes: any[];
   nodeSize?: number;
+  nodeHeight?: number,
+  nodeWidth?: number,
+  nodeSpacingMultiplier?: number,
   nodeSubtypes: any;
   nodeTypes: any;
   readOnly?: boolean;

--- a/src/examples/app.scss
+++ b/src/examples/app.scss
@@ -24,10 +24,13 @@ button {
   margin-right: 10px;
 }
 
+.main-graph-wrapper {
+  height: 100%;
+}
+
 #graph {
   height: 100%;
   width: 100%;
-  display: flex;
 }
 
 .total-nodes {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -20,23 +20,111 @@ $dark-color: black;
 $light-grey: lightgrey;
 $background-color: #f9f9f9;
 
-.view-wrapper {
-  height: 100%;
-  width: 100%;
-  margin: 0;
-  display: flex;
-  box-shadow: none;
-  background: $background-color;
-  transition: opacity 0.167s;
-  opacity: 1;
-  outline: none;
-  user-select: none;
 
-  > .graph {
-    align-content: stretch;
-    flex: 1;
-    width: 100%;
+.main-graph-wrapper {
+  height: 100%;
+
+  .graph-minimap-wrapper {
+    float: right;
+    width: 250px;
+    min-height: 250px;
+  
+    > #minimap {
+      width: 250px;
+      .edge {
+        cursor: default;
+        .edge-text {
+          cursor: default;
+        }
+      }
+      .node {
+        .shape {
+          > use.node {
+            cursor: default;
+          }
+        }
+        .node-text {
+          cursor: default;
+        }    
+      }    
+    }
+    .slider-rect {
+      fill: #000;
+      border: 1px solid black;
+      opacity: 0.1;
+      cursor: default;
+      z-index: 5000;
+    }
+  }
+
+  .view-wrapper {
     height: 100%;
+    margin: 0;
+    display: flex;
+    box-shadow: none;
+    background: $background-color;
+    transition: opacity 0.167s;
+    opacity: 1;
+    outline: none;
+    user-select: none;
+    overflow: hidden;
+    min-height: 50px;
+
+    > .graph {
+      align-content: stretch;
+      flex: 1;
+      width: 100%;
+      height: 100%;
+    }
+
+    .graph-controls {
+      position: absolute;
+      bottom: 30px;
+      left: 15px;
+      z-index: 100;
+      display: grid;
+      grid-template-columns: auto auto;
+      grid-gap: 15px;
+      align-items: center;
+      user-select: none;
+
+      > .slider-wrapper {
+        background-color: white;
+        color: $primary-color;
+        border: solid 1px lightgray;
+        padding: 6.5px;
+        border-radius: 2px;
+
+        > span {
+          display: inline-block;
+          vertical-align: top;
+          margin-top: 2px;
+        }
+
+        > .slider {
+          position: relative;
+          margin-left: 4px;
+          margin-right: 4px;
+          cursor: pointer;
+        }
+      }
+
+      > .slider-button {
+        background-color: white;
+        fill: $primary-color;
+        border: solid 1px lightgray;
+        outline: none;
+        width: 31px;
+        height: 31px;
+        border-radius: 2px;
+        cursor: pointer;
+        margin: 0;
+      }
+    }
+
+    .circle {
+      fill: $light-grey;
+    }
   }
 
   .node {
@@ -113,54 +201,5 @@ $background-color: #f9f9f9;
 
   .arrow {
     fill: $primary-color;
-  }
-
-  .graph-controls {
-    position: absolute;
-    bottom: 30px;
-    left: 15px;
-    z-index: 100;
-    display: grid;
-    grid-template-columns: auto auto;
-    grid-gap: 15px;
-    align-items: center;
-    user-select: none;
-
-    > .slider-wrapper {
-      background-color: white;
-      color: $primary-color;
-      border: solid 1px lightgray;
-      padding: 6.5px;
-      border-radius: 2px;
-
-      > span {
-        display: inline-block;
-        vertical-align: top;
-        margin-top: 2px;
-      }
-
-      > .slider {
-        position: relative;
-        margin-left: 4px;
-        margin-right: 4px;
-        cursor: pointer;
-      }
-    }
-
-    > .slider-button {
-      background-color: white;
-      fill: $primary-color;
-      border: solid 1px lightgray;
-      outline: none;
-      width: 31px;
-      height: 31px;
-      border-radius: 2px;
-      cursor: pointer;
-      margin: 0;
-    }
-  }
-
-  .circle {
-    fill: $light-grey;
   }
 }

--- a/src/utilities/layout-engine/vertical-tree.js
+++ b/src/utilities/layout-engine/vertical-tree.js
@@ -21,9 +21,22 @@ import SnapToGrid from './snap-to-grid';
 
 class VerticalTree extends SnapToGrid {
   adjustNodes(nodes: INode[], nodesMap?: any): INode[] {
-    const { nodeKey, nodeSize } = this.graphViewProps;
-    const size = (nodeSize || 1) * 1.5;
+    const { nodeKey, nodeSize, nodeHeight, nodeWidth, nodeSpacingMultiplier } = this.graphViewProps;
     const g = new dagre.graphlib.Graph();
+
+    const spacing = nodeSpacingMultiplier || 1.5
+    let size = (nodeSize || 1) * spacing; 
+    let height;
+    let width;
+    
+    if (nodeHeight){
+      height = nodeHeight * spacing;
+    }
+    
+    if (nodeWidth){
+      height = nodeWidth * spacing;
+    }
+   
     g.setGraph({});
     g.setDefaultEdgeLabel(() => ({}));
 


### PR DESCRIPTION

"You can change the nodeSize property, however the vertical-tree code assumes that nodes are square (g.setNode(nodeKeyId, { width: size, height: size });). Technically, I believe you can set the nodeSize property to 1 and draw the node SVGs in any size, but then they would overlap.If you're willing to improve the code, I would recommend adding a couple props - nodeWidth and nodeHeight - which can override nodeSize."


